### PR TITLE
Include TU Delft copyright waiver to LICENSE

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,4 @@
+Technische Universiteit Delft hereby disclaims all copyright interest in the
+program “MGA4All” (Various Modelling to Generate Alternatives schemes for
+different energy system optimisation models) written by the Author(s).
+Prof. Dr. Cokky Hilhorst, Dean of Technology, Policy and Management (TPM)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = 'Various Modelling to Generate Alternative schemes for different e
 readme = "README.md"
 requires-python = ">=3.11, <3.14" # upper limit due to gurobipy
 license = "MIT"
+license-files = ["LICENSE"]
 keywords = [ "energy system", "optimisation", "MGA", "PyPSA", "SPORES", "near optimal" ]
 authors = [
   { name = "Christian Doh Dinga", email = "cdoh@tudelft.nl"},
@@ -21,6 +22,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
According to the [TU Delft Research Software Guidelines](https://filelist.tudelft.nl/TUDelft/Over_TU_Delft/Strategie/TU%20Delft%20Research%20Software%20Guidelines.pdf#page=27&zoom=100,0,0) (Section 5, point 2), the license file needs to include a statement that TU Delft waives its copyright in order for an OSS license (such as MIT) to be applied.