### PR TITLE
Refactor history tracking

### DIFF
--- a/src/mga4all/spores.py
+++ b/src/mga4all/spores.py
@@ -40,7 +40,7 @@ def run_spores(
     upper_bound: int = 100,
 ) -> tuple[
     list[tuple[pypsa.Network, pd.Series, linopy.Model]],
-    list[pd.Series],
+    pd.DataFrame,
 ]:
     """Run the SPORES optimization to generate multiple near-optimal solutions."""
     # Validate the SPORES configuration.
@@ -75,7 +75,7 @@ def run_spores(
 
     # Deployment history is needed for `evolving_average` weighting methods. Initialize the history with the least-cost
     # solution's deployment so that it has a memory of the original least-cost solution.
-    deploy_his = [get_deployment(least_cost_network, asset_indices)]
+    deployment_history = pd.DataFrame(get_deployment(least_cost_network, asset_indices))
 
     # Clean up model state so we can make a copy and avoid rebuilding inside the spores loop. PyPSA does not allow
     # copying networks with a solver_model attached, so we need to remove it first.
@@ -90,9 +90,7 @@ def run_spores(
 
             # Calculation of new weights in the 1st iteration depends on the `spores_mode`.
             new_weights = calculate_weights_first_iteration(
-                deploy_his[-1] / max_capacities,
-                config_data["spores_mode"],
-                prev_weights,
+                deployment_history[0] / max_capacities, config_data["spores_mode"], prev_weights
             )
 
         else:
@@ -100,7 +98,7 @@ def run_spores(
             if weighting_method == "random":
                 new_weights = set_weights_random(asset_indices, upper_bound)
             else:
-                deployment = deploy_his[-1]
+                deployment = deployment_history[i - 1]
                 if weighting_method in [
                     "relative_deployment",
                     "relative_deployment_normalized",
@@ -109,9 +107,9 @@ def run_spores(
                     # don't overwrite the reference
                     deployment = deployment / max_capacities
                 elif weighting_method == "evolving_median":
-                    weights = pd.concat(deploy_his, axis="columns").median(axis=1)
+                    weights = deployment_history.median(axis=1)
                 elif weighting_method == "evolving_average":
-                    weights = pd.concat(deploy_his, axis="columns").mean(axis=1)
+                    weights = deployment_history.mean(axis=1)
 
                 new_weights = dispatch_to_correct_weighting_method(
                     deployment, weights, weighting_method
@@ -127,11 +125,9 @@ def run_spores(
         )
 
         history.append((new_spore, new_weights, solved_model))
+        deployment_history[i] = get_deployment(new_spore, asset_indices)
 
-        # Needed for evolving_median and evolving_average weighting methods
-        deploy_his.append(get_deployment(new_spore, asset_indices))
-
-    return history, deploy_his
+    return history, deployment_history
 
 
 def dispatch_to_correct_weighting_method(

--- a/src/mga4all/spores.py
+++ b/src/mga4all/spores.py
@@ -39,9 +39,7 @@ def run_spores(
     weighting_method: str | None = None,
     upper_bound: int = 100,
 ) -> tuple[
-    dict[str, pypsa.Network],
-    dict[str, pd.Series],
-    dict[str, linopy.Model],
+    list[tuple[pypsa.Network, pd.Series, linopy.Model]],
     list[pd.Series],
 ]:
     """Run the SPORES optimization to generate multiple near-optimal solutions."""
@@ -73,9 +71,7 @@ def run_spores(
     )
 
     # Initialize collectors to store results/history
-    spore_networks = {}
-    weights_history = {}
-    spore_models = {}
+    history = []
 
     # Deployment history is needed for `evolving_average` weighting methods. Initialize the history with the least-cost
     # solution's deployment so that it has a memory of the original least-cost solution.
@@ -87,8 +83,8 @@ def run_spores(
         least_cost_network.model.solver_model = None
 
     # Run SPORES
-    for i in range(1, config_data["num_spores"] + 1):
-        if i == 1:
+    for i in range(config_data["num_spores"]):
+        if i == 0:
             # Previous weights are needed for the relative_deployment weighting methods.
             prev_weights = initialize_weights(asset_indices)
 
@@ -109,10 +105,9 @@ def run_spores(
                     "relative_deployment",
                     "relative_deployment_normalized",
                 ]:
-                    weights = weights_history[f"weights_{i - 1}"]
-                    deployment = (
-                        deployment / max_capacities
-                    )  # don't overwrite the history reference
+                    _, weights, _ = history[i - 1]
+                    # don't overwrite the reference
+                    deployment = deployment / max_capacities
                 elif weighting_method == "evolving_median":
                     weights = pd.concat(deploy_his, axis="columns").median(axis=1)
                 elif weighting_method == "evolving_average":
@@ -131,14 +126,12 @@ def run_spores(
             network, modified_model, solver_options
         )
 
-        weights_history[f"weights_{i}"] = new_weights
-        spore_networks[f"spore_{i}"] = new_spore
-        spore_models[f"model_{i}"] = solved_model
+        history.append((new_spore, new_weights, solved_model))
 
         # Needed for evolving_median and evolving_average weighting methods
         deploy_his.append(get_deployment(new_spore, asset_indices))
 
-    return spore_networks, weights_history, spore_models, deploy_his
+    return history, deploy_his
 
 
 def dispatch_to_correct_weighting_method(


### PR DESCRIPTION
> [!NOTE]
> This PR builds on top of #17 , so is made as a PR to that branch to make the diff show only the relevant differences

Two main changes in how returned data is tracked in the `run_spores()` function:
1. Instead of having separately defined dictionaries with keys formatted like `f"weights_{i}"`, just use a list of tuples.
   - This does mean a switch from 'named' 1-indexing to 0-indexing
2. Instead of a list of deployment series, directly make it a dataframe. This omits the need for repeated `pd.concat(deployment_history)` calls, since each deployment series is just added at the end after every iteration.

I'm not entirely happy with the final returned data, but that is something to discuss at a higher level.