### PR TITLE
Use validated config object instead of input dictionary

### DIFF
--- a/src/mga4all/spores.py
+++ b/src/mga4all/spores.py
@@ -7,8 +7,9 @@ import pandas as pd
 import pypsa
 
 from .validate import (
-    validate_spores_configuration,
+    PYPSAConfig,
     PYPSA_DATAFRAME_NAMES,
+    SporesConfig,
     WeightingMethod,
 )
 
@@ -28,11 +29,10 @@ def run_spores(
     -------
     spore_networks: list[pypsa.Network]
     """
-    validate_spores_configuration(spores_config)
+    config = PYPSAConfig(**spores_config).SPORES
 
-    config_data = spores_config["SPORES"]
-    weighting_method = config_data.get("weighting_method")
-    asset_indices = get_asset_multi_index(config_data)
+    weighting_method = config.weighting_method
+    asset_indices = get_asset_multi_index(config)
     max_capacities = get_max_capacities(least_cost_network, asset_indices)
 
     # Check if the network is already optimized, else raise an error.
@@ -43,7 +43,7 @@ def run_spores(
 
     # First spore uses zeros or relative deployment as weights
     prev_weights = pd.Series(0.0, index=asset_indices, name="weights")
-    if not config_data["intensify"]:
+    if not config.intensify:
         relative_deployment = (
             get_deployment(least_cost_network, asset_indices) / max_capacities
         )
@@ -51,7 +51,7 @@ def run_spores(
             relative_deployment, prev_weights
         )
     first_spore = evaluate_weights(
-        least_cost_network, prev_weights, config_data, solver_options
+        least_cost_network, prev_weights, config, solver_options
     )
     spore_networks = [first_spore]
     deploy_his = pd.DataFrame(  # Record history for evolving_average/median methods
@@ -62,7 +62,7 @@ def run_spores(
     )
 
     # Run SPORES
-    for i in range(config_data["num_spores"] - 1):
+    for i in range(config.num_spores - 1):
         match weighting_method:
             case WeightingMethod.RANDOM:
                 new_weights = set_weights_random(asset_indices, upper_bound)
@@ -92,7 +92,7 @@ def run_spores(
 
         logger.debug(f"weights for iteration {i}: {new_weights}")
         new_spore = evaluate_weights(
-            least_cost_network, new_weights, config_data, solver_options
+            least_cost_network, new_weights, config, solver_options
         )
         spore_networks.append(new_spore)
 
@@ -105,7 +105,7 @@ def run_spores(
 def evaluate_weights(
     base_network: pypsa.Network,
     weights: pd.Series,
-    config_data: dict,
+    config_data: SporesConfig,
     solver_options: dict,
 ) -> pypsa.Network:
     """Evaluate a PyPSA network with objective modified according to given weights
@@ -126,12 +126,12 @@ def evaluate_weights(
     return new_spore
 
 
-def get_asset_multi_index(configuration: dict) -> pd.MultiIndex:
+def get_asset_multi_index(configuration: SporesConfig) -> pd.MultiIndex:
     """Unpack the spore technologies information into a flat datastructure."""
     entries = [
-        (asset_group["component"], asset_group["attribute"], asset)
-        for asset_group in configuration["spore_technologies"]
-        for asset in asset_group["assets"]
+        (asset_group.component, asset_group.attribute, asset)
+        for asset_group in configuration.spore_technologies
+        for asset in asset_group.assets
     ]
     return pd.MultiIndex.from_tuples(entries, names=["component", "attribute", "asset"])
 
@@ -237,7 +237,10 @@ def optimize_model_and_assign_solution_to_network(
 
 
 def create_modified_model(
-    n: pypsa.Network, configuration: dict, optimal_cost: float, weights: pd.Series
+    n: pypsa.Network,
+    configuration: SporesConfig,
+    optimal_cost: float,
+    weights: pd.Series,
 ) -> linopy.Model:
     """Create the modified model (with the new objective and budget constraint) from the least-cost network."""
     # 1. Access the underlying linopy model of the least-cost pypsa network
@@ -246,7 +249,7 @@ def create_modified_model(
     )  # suppress FutureWarning about objective constant
 
     # 2. Add the budget constraint to the model
-    slack = configuration["spores_slack"]
+    slack = configuration.spores_slack
     least_cost_objective = m.objective
     if not isinstance(least_cost_objective, linopy.LinearExpression):
         least_cost_objective = least_cost_objective.expression
@@ -260,38 +263,13 @@ def create_modified_model(
     return m
 
 
-def modified_model_for_spores_run(
-    n: pypsa.Network,
-    m: linopy.Model,
-    configuration: dict,
-    optimal_cost: float,
-    weights: pd.Series,
-) -> linopy.Model:
-    """Modify the model given model to add the new objective function and budget constraint."""
-    # 1. Add the budget constraint to the model
-    slack = configuration["spores_slack"]
-    least_cost_objective = m.objective
-    if not isinstance(least_cost_objective, linopy.LinearExpression):
-        least_cost_objective = least_cost_objective.expression
-    m.add_constraints(
-        least_cost_objective <= (1 + slack) * optimal_cost, name="budget-constraint"
-    )
-
-    # 2. Modify the objective function
-    m = modify_objective(n, m, weights, configuration)
-
-    return m
-
-
 def modify_objective(
-    n: pypsa.Network, m: linopy.Model, weights: pd.Series, configuration: dict
+    n: pypsa.Network, m: linopy.Model, weights: pd.Series, configuration: SporesConfig
 ) -> linopy.Model:
     """Modify the objective function to optimize technology capacities instead of costs."""
-    diversification_coeff = float(configuration.get("diversification_coefficient"))
-    intensification_coeff = configuration.get("intensification_coefficient")
-    if intensification_coeff is not None:
-        intensification_coeff = float(intensification_coeff)
-    intensifiable_technologies = configuration.get("intensifiable_technologies")
+    diversification_coeff = configuration.diversification_coefficient
+    intensification_coeff = configuration.intensification_coefficient
+    intensifiable_technologies = configuration.intensifiable_technologies
 
     group_levels = ["component", "attribute"]
     objective_expressions = []
@@ -310,7 +288,7 @@ def modify_objective(
         # Build intensification terms, starting with zeros
         intensification_final_coeffs = pd.Series(0.0, index=tech_weights.index)
 
-        if configuration["intensify"] and intensification_coeff != 0:
+        if configuration.intensify and intensifiable_technologies:
             intensify_mask = tech_weights.index.isin(intensifiable_technologies)
             # Apply the value only to the selected technologies
             intensification_final_coeffs[intensify_mask] = intensification_coeff

--- a/src/mga4all/validate.py
+++ b/src/mga4all/validate.py
@@ -132,8 +132,3 @@ class SporesConfig(BaseModel):
 
 class PYPSAConfig(BaseModel):
     SPORES: SporesConfig
-
-
-def validate_spores_configuration(config: dict):
-    """Validate a SPORES YAML config against the specified requirements."""
-    PYPSAConfig.model_validate(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ class MockPypsaNetwork:
 
 
 @pytest.fixture()
-def pypsa_spores_config():
+def pypsa_spores_config_dict():
     """Fixture for a sample SPORES configuration."""
     with open("configs/spores_configs/test_spores_configs/test_diversify.yaml") as f:
         config = yaml.safe_load(f)

--- a/tests/test_create_and_optimize_model_spore.py
+++ b/tests/test_create_and_optimize_model_spore.py
@@ -44,7 +44,8 @@ def test_create_modified_model(mock_pypsa_and_linopy_env):
     """Tests that the function correctly adds the budget constraint and calls other functions in the correct order."""
     mock_network, mock_model, mock_modify_objective = mock_pypsa_and_linopy_env
 
-    config = {"spores_slack": 0.1}
+    config = MagicMock(name="MockConfig")
+    config.spores_slack = 0.1
     optimal_cost = 1000.0
     weights = {"some": "weights"}
 
@@ -64,7 +65,7 @@ def test_create_modified_model(mock_pypsa_and_linopy_env):
 
     # Manually build the expected constraint expression
     expected_lhs = mock_model.objective
-    expected_rhs = (1 + config["spores_slack"]) * optimal_cost
+    expected_rhs = (1 + config.spores_slack) * optimal_cost
 
     # Linopy constraints have .lhs, .rhs, and .sign attributes
     assert_linequal(actual_constraint.lhs, expected_lhs)

--- a/tests/test_modify_spore_objective.py
+++ b/tests/test_modify_spore_objective.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import linopy
 import pandas as pd
 from .conftest import MockPypsaNetwork
@@ -25,10 +27,9 @@ def test_modify_objective_diversify_only(asset_indices):
     """Tests the standard 'diversify' mode. The objective should only include the diversification term."""
     n, m = setup_model_and_network()
     weights = pd.Series([0.5, 1.0, 0.0], index=asset_indices)
-    config = {
-        "intensify": False,
-        "diversification_coefficient": 10,
-    }
+    config = MagicMock(name="MockConfig")
+    config.intensify = False
+    config.diversification_coefficient = 10
 
     m = modify_objective(n, m, weights, config)
 
@@ -52,12 +53,12 @@ def test_modify_objective_intensify_and_diversify(asset_indices):
     """Tests 'intensify and diversify' mode. The objective should include both terms."""
     n, m = setup_model_and_network()
     weights = pd.Series([0.5, 1.0, 0.2], index=asset_indices)
-    config = {
-        "intensify": True,
-        "diversification_coefficient": 10,
-        "intensification_coefficient": 100,
-        "intensifiable_technologies": ["gas"],
-    }
+    config = MagicMock(name="MockConfig")
+    config.intensify = True
+    config.diversification_coefficient = 10
+    config.intensification_coefficient = 100
+    config.intensifiable_technologies = ["gas"]
+
     m = modify_objective(n, m, weights, config)
     capacity_vars = m.variables["Generator-p_nom"]
     expected_coeffs = pd.Series(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from mga4all.validate import validate_spores_configuration
+from mga4all.validate import PYPSAConfig
 
 
 @pytest.mark.parametrize(
@@ -16,11 +16,11 @@ from mga4all.validate import validate_spores_configuration
         "spore_technologies",
     ],
 )
-def test_missing_keys(key, pypsa_spores_config):
+def test_missing_keys(key, pypsa_spores_config_dict):
     """Test that a missing key is correctly caught."""
-    del pypsa_spores_config["SPORES"][key]
+    del pypsa_spores_config_dict["SPORES"][key]
     with pytest.raises(ValidationError):
-        validate_spores_configuration(pypsa_spores_config)
+        PYPSAConfig.model_validate(pypsa_spores_config_dict)
 
 
 @pytest.mark.parametrize(
@@ -35,11 +35,11 @@ def test_missing_keys(key, pypsa_spores_config):
         ("spore_technologies", []),
     ],
 )
-def test_invalid_values(key, value, pypsa_spores_config):
+def test_invalid_values(key, value, pypsa_spores_config_dict):
     """Test that invalid values are caught."""
-    pypsa_spores_config["SPORES"][key] = value
+    pypsa_spores_config_dict["SPORES"][key] = value
     with pytest.raises(ValidationError):
-        validate_spores_configuration(pypsa_spores_config)
+        PYPSAConfig.model_validate(pypsa_spores_config_dict)
 
 
 @pytest.mark.parametrize(
@@ -51,15 +51,15 @@ def test_invalid_values(key, value, pypsa_spores_config):
     ],
     ids=["missing coefficient", "missing technologies", "both missing"],
 )
-def test_missing_intensification_options(values, pypsa_spores_config):
+def test_missing_intensification_options(values, pypsa_spores_config_dict):
     """Test that missing intensification options are caught when mode includes `intensify`."""
-    spores_config = pypsa_spores_config["SPORES"]
+    spores_config = pypsa_spores_config_dict["SPORES"]
     spores_config["intensify"] = True
     for key, value in values.items():
         spores_config[key] = value
 
     with pytest.raises(ValidationError) as exception_info:
-        validate_spores_configuration(pypsa_spores_config)
+        PYPSAConfig.model_validate(pypsa_spores_config_dict)
     assert "provided when `intensify` is `True`" in str(exception_info.value)
 
 
@@ -71,32 +71,32 @@ def test_missing_intensification_options(values, pypsa_spores_config):
     ],
     ids=["missing coefficient", "missing technologies"],
 )
-def test_missing_optional_intensification_options(values, pypsa_spores_config):
+def test_missing_optional_intensification_options(values, pypsa_spores_config_dict):
     """Test that a lacking intensification option is caught."""
-    spores_config = pypsa_spores_config["SPORES"]
+    spores_config = pypsa_spores_config_dict["SPORES"]
     for key, value in values.items():
         spores_config[key] = value
 
     with pytest.raises(ValidationError) as exception_info:
-        validate_spores_configuration(pypsa_spores_config)
+        PYPSAConfig.model_validate(pypsa_spores_config_dict)
     assert "both provided or omitted together" in str(exception_info.value)
 
 
-def test_intensifiable_subset(pypsa_spores_config):
+def test_intensifiable_subset(pypsa_spores_config_dict):
     """Test that it is caught if an intensifiable asset is not previously defined."""
-    spores_config = pypsa_spores_config["SPORES"]
+    spores_config = pypsa_spores_config_dict["SPORES"]
     spores_config["intensification_coefficient"] = 1.0
     spores_config["intensifiable_technologies"] = ["not present"]
 
     with pytest.raises(ValidationError) as exception_info:
-        validate_spores_configuration(pypsa_spores_config)
+        PYPSAConfig.model_validate(pypsa_spores_config_dict)
     assert "were not previously defined" in str(exception_info.value)
 
 
-def test_duplicates(pypsa_spores_config):
+def test_duplicates(pypsa_spores_config_dict):
     """Test that a duplicate asset in `spore_technologies` is caught."""
-    pypsa_spores_config["SPORES"]["spore_technologies"][0]["assets"].append("OCGT")
+    pypsa_spores_config_dict["SPORES"]["spore_technologies"][0]["assets"].append("OCGT")
 
     with pytest.raises(ValidationError) as exception_info:
-        validate_spores_configuration(pypsa_spores_config)
+        PYPSAConfig.model_validate(pypsa_spores_config_dict)
     assert "Duplicate asset entry found" in str(exception_info.value)


### PR DESCRIPTION
While PR #14 has replaced the validation of the configuration, the dictionary with originally loaded data is still used in `spores.py`. This PR replaces all occurrences of dictionary access with the dataclass-object as produced by Pydantic after parsing.

Benefits:
- Any type coercion/casting is done at validation time
- Typing information is more clearly available
- Removes need for separate `validate_spores_configuration` function